### PR TITLE
Encode HTMLEntities in node values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+Gemfile.lock
+tags
 tmp
 pkg


### PR DESCRIPTION
Hi, I added a routine to encode XML values, translating dangerous characters in their HTML entities.

I was reviewing OBS code (https://github.com/openSUSE/open-build-service/blob/83436a2f5ce67e7d1df2370a4bc681517a1982b1/src/api/app/models/bs_request.rb#L154) and I found that values containing HTML were saved into DB, so resulting in a potentially stored XSS.